### PR TITLE
Fix module output autocomplete for local modules

### DIFF
--- a/company-terraform.el
+++ b/company-terraform.el
@@ -75,8 +75,10 @@
             (while (re-search-forward "\n[[:space:]]*source[[:space:]]*=[[:space:]]*\"\\([^\"]*\\)\"" end t)
               (let* ((module-dir-hash (secure-hash 'md5 (concat "1." module-name ";" (match-string-no-properties 1))))
                      (module-dir (concat dir ".terraform/modules/" module-dir-hash)))
-                ;; TODO: If the dir does not exist, use data straight from source dir
-                (puthash module-name module-dir modules-with-dirs)))
+                ;; If the dir does not exist, use data straight from source dir
+                (if (file-directory-p module-dir)
+                    (puthash module-name module-dir modules-with-dirs)
+                  (puthash module-name (concat dir (match-string-no-properties 1)) modules-with-dirs))))
             ))))
     (list datas resources variables outputs locals modules modules-with-dirs)))
 


### PR DESCRIPTION
I was getting an "file or directory doesn't exists" error for output completion of local modules. This does what the leftover TODO comment suggested, adding the source dir to modules-with-dirs

Maybe there is a smarter way of concatenating paths but this works in my case locally.