### PR TITLE
Pass through to next backend when inside string

### DIFF
--- a/company-terraform.el
+++ b/company-terraform.el
@@ -148,7 +148,8 @@ which lasts serval seconds."
                  (skip-syntax-backward "w")
                  (point))))))
      ;; Inside resource/data block
-     ((and (eq ?{ (char-after curr-ppos))
+     ((and (not string-state)
+           (eq ?{ (char-after curr-ppos))
            (save-excursion
              (goto-char curr-ppos)
              (re-search-backward "\\(resource\\|data\\|module\\)[[:space:]\n]*\"\\([^\"]*\\)\"[[:space:]\n]*\\(\"[^\"]*\"[[:space:]\n]*\\)?\\=" nil t)))


### PR DESCRIPTION
When inside string and no interpolation company-terraform does not do anything, so pass through to further backends like `company-files`. 

Primary use case is to complete paths inside local source blocks. 